### PR TITLE
Heroku fix - deprecated/incompatible packages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@autocomplete/material-ui": "^0.0.17",
-    "@devexpress/dx-react-scheduler-material-ui": "^4.0.5",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@fontsource/league-spartan": "^5.0.15",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@devexpress/dx-react-core": "^4.0.5",
     "@devexpress/dx-react-scheduler": "^4.0.5",
     "@devexpress/dx-react-scheduler-material-ui": "^4.0.5",
-    "@material-ui/core": "^4.12.4",
+    "@mui/material": "^5.14.17",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
@@ -11,7 +11,6 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
     "mailgen": "^2.0.28",
-    "material-ui": "^0.20.0",
     "mdb-ui-kit": "^6.4.2",
     "mongodb": "^6.2.0",
     "mongoose": "^7.6.3",
@@ -39,8 +38,8 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon server.js",
-    "heroku-postbuild": " NPM_CONFIG_PRODUCTION=false npm install --prefix frontend &&   npm run build --prefix frontend"
+    "start": "node server.js",
+    "heroku-postbuild": " NPM_CONFIG_PRODUCTION=false npm install --prefix frontend && npm run build --prefix frontend"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
When testing, may have to delete both package-lock.json, both node_modules, and run npm install.
Fixing deprecated material ui package from root package.json, taking out problematic calendar dependency in frontend package.json. 